### PR TITLE
Update router.js

### DIFF
--- a/src/server/router.js
+++ b/src/server/router.js
@@ -37,7 +37,7 @@ module.exports = function(settings) {
     if (!valid) return res.sendStatus(401);
 
     // Events API challenge request
-    if (challenge) return res.send(challenge);
+    if (challenge) return res.setHeader('Content-Type', 'text/plain').send(challenge)
 
     // Load workspace data and continue
     return req.slack.load().then(done);


### PR DESCRIPTION
Provide content-type override to set plain text header. Slack no longer accepts `text/html` (see: https://api.slack.com/events/url_verification)